### PR TITLE
Fixed undefined uniq_id variable issue

### DIFF
--- a/scrapyelasticsearch/scrapyelasticsearch.py
+++ b/scrapyelasticsearch/scrapyelasticsearch.py
@@ -37,6 +37,7 @@ class ElasticSearchPipeline(object):
 
     def index_item(self, item):
         if self.settings['ELASTICSEARCH_UNIQ_KEY']:
+            uniq_key = self.settings['ELASTICSEARCH_UNIQ_KEY']
             local_id = hashlib.sha1(item[uniq_key)]).hexdigest()
             log.msg("Generated unique key %s" % local_id, level=self.settings['ELASTICSEARCH_LOG_LEVEL'])
             op_type = 'none'


### PR DESCRIPTION
The uniq_key variable is undefined in this context and this error comes up

`exceptions.NameError: global name 'uniq_key' is not defined`

This patch fixes the problem.
