### PR TITLE
Fix indexing error

### DIFF
--- a/scrapyelasticsearch/scrapyelasticsearch.py
+++ b/scrapyelasticsearch/scrapyelasticsearch.py
@@ -40,7 +40,7 @@ class ElasticSearchPipeline(object):
             uniq_key = self.settings['ELASTICSEARCH_UNIQ_KEY']
             local_id = hashlib.sha1(item[uniq_key]).hexdigest()
             log.msg("Generated unique key %s" % local_id, level=self.settings['ELASTICSEARCH_LOG_LEVEL'])
-            op_type = 'none'
+            op_type = 'index'
         else:
             op_type = 'create'
             local_id = item['id']


### PR DESCRIPTION
Hi there,

I've changed the 'op_type' from none to index. It was generating this error.

`pyes.exceptions.ElasticSearchException: opType [none] not allowed, either [index] or [create] are allowed`

Cheers,

Ignacio
