### PR TITLE
Fix settings

### DIFF
--- a/scrapyelasticsearch/scrapyelasticsearch.py
+++ b/scrapyelasticsearch/scrapyelasticsearch.py
@@ -30,7 +30,13 @@ class ElasticSearchPipeline(object):
         ext = cls()
         ext.settings = crawler.settings
 
-        basic_auth = {'username': ext.settings['ELASTICSEARCH_USERNAME'], 'password': ext.settings['ELASTICSEARCH_PASSWORD']}
+        basic_auth = {}
+
+        if (ext.settings['ELASTICSEARCH_USERNAME']):
+            basic_auth['username'] = ext.settings['ELASTICSEARCH_USERNAME']
+
+        if (ext.settings['ELASTICSEARCH_PASSWORD']):
+            basic_auth['password'] = ext.settings['ELASTICSEARCH_PASSWORD']
 
         if ext.settings['ELASTICSEARCH_PORT']:
             uri = "%s:%d" % (ext.settings['ELASTICSEARCH_SERVER'], ext.settings['ELASTICSEARCH_PORT'])


### PR DESCRIPTION
Hi there!

It looks like by using get_project_settings you can only retrieve the settings in the config file.
In order to override settings like ELASTICSEARCH_INDEX from other parts of the spider (like the command line), the from_crawler method must be implemented and used to load settings.
