### PR TITLE
make it possible to retry in case of failures

### DIFF
--- a/scrapyelasticsearch/scrapyelasticsearch.py
+++ b/scrapyelasticsearch/scrapyelasticsearch.py
@@ -96,7 +96,7 @@ class ElasticSearchPipeline(object):
 
         self.items_buffer.append(index_action)
 
-        if len(self.items_buffer) == self.settings.get('ELASTICSEARCH_BUFFER_LENGTH', 500):
+        if len(self.items_buffer) >= self.settings.get('ELASTICSEARCH_BUFFER_LENGTH', 500):
             self.send_items()
             self.items_buffer = []
 


### PR DESCRIPTION
otherwise if send_items failed for any reason, the condition will never get satisfied, therefore the buffer will keeping growing until out of memory.