### PR TITLE
Fix: str key was never encoded in utf-8. 

### DIFF
--- a/scrapyelasticsearch/scrapyelasticsearch.py
+++ b/scrapyelasticsearch/scrapyelasticsearch.py
@@ -71,7 +71,9 @@ class ElasticSearchPipeline(object):
     def get_unique_key(self, unique_key):
         if isinstance(unique_key, list):
             unique_key = unique_key[0].encode('utf-8')
-        elif not isinstance(unique_key, string_types):
+        elif isinstance(unique_key, string_types):
+            unique_key = unique_key.encode('utf-8')
+        else:
             raise Exception('unique key must be str or unicode')
 
         return unique_key


### PR DESCRIPTION
Fix to https://github.com/knockrentals/scrapy-elasticsearch/issues/45.
As scrapy put item in list by default, i think key were always in list. Now a 'real' string in also encoded.