### PR TITLE
Add support to create index with mapping definition

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,8 @@ Available parameters (in settings.py)
         'CLIENT_KEY': '/path/to/client_key.pem'
   }
 
+  ELASTICSEARCH_INDEX_MAPPING - optional field, file location of mapping definition (should be a json file)
+
 
 Here is an example app (dirbot https://github.com/jayzeng/dirbot) in case you are still confused.
 
@@ -65,6 +67,7 @@ See requirements.txt
 
 Changelog
 =========
+* 0.10: Added support for create index with mapping definition
 * 0.9: Accept custom CA cert to connect to es clusters
 * 0.8: Added support for NTLM authentification
 * 0.7.1: Added date format to the index name and a small bug fix

--- a/scrapyelasticsearch/scrapyelasticsearch.py
+++ b/scrapyelasticsearch/scrapyelasticsearch.py
@@ -156,8 +156,7 @@ class ElasticSearchPipeline(object):
                 self.process_item(each, spider)
         else:
             self.index_item(item)
-            logging.debug('Item sent to Elastic Search %s' %
-                          self.settings['ELASTICSEARCH_INDEX'])
+            logging.debug('Item sent to Elastic Search %s' % self.settings['ELASTICSEARCH_INDEX'])
             return item
 
     def close_spider(self, spider):

--- a/scrapyelasticsearch/scrapyelasticsearch.py
+++ b/scrapyelasticsearch/scrapyelasticsearch.py
@@ -91,7 +91,7 @@ class ElasticSearchPipeline(object):
         ext.es = cls.init_es_client(crawler.settings)
 
         if 'ELASTICSEARCH_INDEX_MAPPING' in ext.settings:
-            cls.create_index_with_mapping(ext)
+            cls.create_index_with_mapping(cls, ext)
 
         return ext
 
@@ -163,8 +163,8 @@ class ElasticSearchPipeline(object):
         if len(self.items_buffer):
             self.send_items()
 
-    def create_index_with_mapping(ext):
-        index_name = ext.settings['ELASTICSEARCH_INDEX']
+    def create_index_with_mapping(self, ext):
+        index_name = self.create_index_name(ext)
         mapping_file = ext.settings['ELASTICSEARCH_INDEX_MAPPING']
 
         if ext.es.indices.exists(index_name):
@@ -175,3 +175,13 @@ class ElasticSearchPipeline(object):
             mapping_data = json.loads(file.read())
             ext.es.indices.create(
                 index=index_name, ignore=400, body=mapping_data)
+
+    def create_index_name(ext):
+        index_name = ext.settings['ELASTICSEARCH_INDEX']
+        index_suffix_format = ext.settings['ELASTICSEARCH_INDEX_DATE_FORMAT']
+
+        if index_suffix_format:
+            dt = datetime.now()
+            index_name += "-" + datetime.strftime(dt, index_suffix_format)
+
+        return index_name


### PR DESCRIPTION
Hi!

I'm facing a problem with my current project where I need to create a rotating index and for this, I need to obey some mapping definitions, that's the reason I crating this PR collaborating with this project and also trying to help features requests [here](https://github.com/jayzeng/scrapy-elasticsearch/issues/51) and [here](https://github.com/jayzeng/scrapy-elasticsearch/issues/61).

I've decided to use property "ELASTICSEARCH_INDEX_MAPPING" to set file location of mapping definition instead of writing the definition itself inside the "settings.py" file, that's because these definitions tend to grow a lot and can easily pollute the code, eg: `{
  "settings" : {
    "index" : {
      "number_of_shards" : 1,
      "number_of_replicas" : 1
    },
    "analysis": {
      "analyzer": {
        "my_analyzer": {
          "type": "snowball"
        }
      }
    }
  },
  "mappings": {
    "dynamic": "strict",
    "properties": {
      "source": { "type": "text" },
      "url": { "type": "text" },
      "name": { "type": "text",
        "analyzer": "my_analyzer",
        "search_analyzer": "my_analyzer"
      },
      "phone": { "type": "text" },
      "photo": { "type": "text" },
      "details": { "type": "text",
        "analyzer": "my_analyzer",
        "search_analyzer": "my_analyzer"
      },
      "created_at": { "type": "date" }
    }
  }
}` 

I decided to make it simple and clean just setting the file path of the index definition.


**DISCLAIMER:** I'm not sure if is the right decision to call the function "create_index_with_mapping" inside the function called "from_crawler". I would love to know your option about that.

 Thanks for your project it's helping me a lot and I hope I can help a little bit with it too.

Cheers
Anderson Carubelli